### PR TITLE
Drop --admin on auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,4 +89,4 @@ jobs:
       - name: Auto-merge PR
         env:
           GH_TOKEN: ${{ secrets.AUTOMERGE_PAT }}
-        run: gh pr merge ${{ github.event.pull_request.number }} --squash --delete-branch --admin -R ${{ github.repository }}
+        run: gh pr merge ${{ github.event.pull_request.number }} --squash --delete-branch -R ${{ github.repository }}


### PR DESCRIPTION
Stale CircleCI required check has been removed from branch protection; admin bypass no longer needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)